### PR TITLE
Fix realtime monitor blocking issue

### DIFF
--- a/network_monitor.c
+++ b/network_monitor.c
@@ -16,8 +16,22 @@ void start_network_monitor(const char *device) {
         return;
     }
     printf("[Network Monitor] Monitoring device: %s\n", device);
-    // Capture 5 packets for demonstration.
-    pcap_loop(handle, 5, packet_handler, NULL);
+    // Capture up to 5 packets, but do not block indefinitely
+    int packets_captured = 0;
+    int timeouts = 0;
+    while (packets_captured < 5 && timeouts < 5) {
+        struct pcap_pkthdr *header;
+        const u_char *packet;
+        int res = pcap_next_ex(handle, &header, &packet);
+        if (res == 1) {
+            packet_handler(NULL, header, packet);
+            packets_captured++;
+        } else if (res == 0) { // timeout
+            timeouts++;
+        } else {
+            break;
+        }
+    }
     pcap_close(handle);
 }
 


### PR DESCRIPTION
## Summary
- prevent realtime monitor from blocking forever by using non-blocking inotify and timeout logic
- avoid network monitor hangs by limiting capture attempts

## Testing
- `make clean && make`

------
https://chatgpt.com/codex/tasks/task_e_6852c7c050bc832987486c65b11c0dc1